### PR TITLE
Put all TestBase-derived unit tests in a single collection

### DIFF
--- a/Collections.Pooled.Tests/TestBase.NonGeneric.cs
+++ b/Collections.Pooled.Tests/TestBase.NonGeneric.cs
@@ -4,12 +4,14 @@
 
 using System;
 using System.Collections.Generic;
+using Xunit;
 
 namespace Collections.Pooled.Tests
 {
     /// <summary>
     /// Provides a base set of nongeneric operations that are used by all other testing interfaces.
     /// </summary>
+    [Collection("TestBase Collection")] // this prevents subclass tests from being run in parallel
     public abstract class TestBase : IDisposable
     {
         private readonly PooledList<IDisposable> _disposables = new PooledList<IDisposable>();
@@ -20,8 +22,6 @@ namespace Collections.Pooled.Tests
         {
             yield return new object[] { 0 };
             yield return new object[] { 1 };
-            //for (int i = 2; i < 11; i++)
-            //    yield return new object[] { i };
             yield return new object[] { 5 };
             yield return new object[] { 75 };
         }

--- a/Collections.Pooled.Tests/TestBase.NonGeneric.cs
+++ b/Collections.Pooled.Tests/TestBase.NonGeneric.cs
@@ -11,7 +11,6 @@ namespace Collections.Pooled.Tests
     /// <summary>
     /// Provides a base set of nongeneric operations that are used by all other testing interfaces.
     /// </summary>
-    [Collection("TestBase Collection")] // this prevents subclass tests from being run in parallel
     public abstract class TestBase : IDisposable
     {
         private readonly PooledList<IDisposable> _disposables = new PooledList<IDisposable>();

--- a/Collections.Pooled/PooledDictionary.cs
+++ b/Collections.Pooled/PooledDictionary.cs
@@ -845,6 +845,8 @@ namespace Collections.Pooled
             // use the existing capacity without actually resizing.
             if (_buckets.Length >= newSize && _entries.Length >= newSize)
             {
+                Array.Clear(_buckets, 0, _buckets.Length);
+                Array.Clear(_entries, _size, newSize - _size);
                 buckets = _buckets;
                 entries = _entries;
                 replaceArrays = false;
@@ -852,8 +854,9 @@ namespace Collections.Pooled
             else
             {
                 buckets = s_bucketPool.Rent(newSize);
-                Array.Clear(buckets, 0, buckets.Length);
                 entries = s_entryPool.Rent(newSize);
+
+                Array.Clear(buckets, 0, buckets.Length);
                 Array.Copy(_entries, 0, entries, 0, count);
                 replaceArrays = true;
             }


### PR DESCRIPTION
This avoids a concurrency issue during test runs.