### PR TITLE
Fix List Clear Array bug

### DIFF
--- a/Collections.Pooled/PooledList.cs
+++ b/Collections.Pooled/PooledList.cs
@@ -585,7 +585,7 @@ namespace Collections.Pooled
             if (size > 0 && _clearOnFree)
             {
                 // Clear the elements so that the gc can reclaim the references.
-                Array.Clear(_items, 0, _size);
+                Array.Clear(_items, 0, size);
             }
         }
 


### PR DESCRIPTION
Array.Clear (Array array, int index, int length); is used with **_size** (which was set to 0) as length, should be used with method variable **size**